### PR TITLE
Add configuration option for max chonkiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Fabric Example Mod
+# ChonkySheep
 
-## Setup
+Make sheep get chonky when they eat grass, they will have more wool than a normal sheep!
 
-For setup instructions please see the [fabric wiki page](https://fabricmc.net/wiki/tutorial:setup) that relates to the IDE that you are using.
 
-## License
 
-This template is available under the CC0 license. Feel free to learn from it and incorporate it in your own projects.
+Whenever a sheep eats grass but already has wool the sheep grows more wool up to 2x the size they normally are! There are 20 different "chonky" levels.
+
+The more chonky a sheep is the more wool it drops when sheared.

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
+    maven { url "https://maven.shedaniel.me/" }
+    maven { url "https://maven.terraformersmc.com" }
 }
 
 dependencies {
@@ -29,6 +31,10 @@ dependencies {
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
+    modApi("me.shedaniel.cloth:cloth-config-fabric:5.0.38") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
+    modImplementation "com.terraformersmc:modmenu:2.0.13"
 }
 
 processResources {

--- a/src/main/java/com/suppergerrie2/chonkysheep/ChonkySheepConfig.java
+++ b/src/main/java/com/suppergerrie2/chonkysheep/ChonkySheepConfig.java
@@ -1,0 +1,11 @@
+package com.suppergerrie2.chonkysheep;
+
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+
+@Config(name = ChonkySheepMod.MOD_ID)
+public class ChonkySheepConfig implements ConfigData {
+    @ConfigEntry.BoundedDiscrete(min=0, max=64)
+    public int maxChonkyness = 20;
+}

--- a/src/main/java/com/suppergerrie2/chonkysheep/ChonkySheepMod.java
+++ b/src/main/java/com/suppergerrie2/chonkysheep/ChonkySheepMod.java
@@ -2,6 +2,8 @@ package com.suppergerrie2.chonkysheep;
 
 import com.google.gson.GsonBuilder;
 import com.suppergerrie2.chonkysheep.entities.ChonkySheepEntity;
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
@@ -12,6 +14,7 @@ import net.minecraft.util.registry.Registry;
 public class ChonkySheepMod implements ModInitializer {
 
     public static final String MOD_ID = "schonkysheep";
+    public static ChonkySheepConfig config;
 
     // @formatter:off
 	public static final EntityType<ChonkySheepEntity> CHONKY_SHEEP = Registry.register(
@@ -24,5 +27,7 @@ public class ChonkySheepMod implements ModInitializer {
     @Override
     public void onInitialize() {
         FabricDefaultAttributeRegistry.register(CHONKY_SHEEP, ChonkySheepEntity.createChonkySheepAttributes());
+        AutoConfig.register(ChonkySheepConfig.class, JanksonConfigSerializer::new);
+        config = AutoConfig.getConfigHolder(ChonkySheepConfig.class).getConfig();
     }
 }

--- a/src/main/java/com/suppergerrie2/chonkysheep/ModMenuIntegration.java
+++ b/src/main/java/com/suppergerrie2/chonkysheep/ModMenuIntegration.java
@@ -1,0 +1,13 @@
+package com.suppergerrie2.chonkysheep;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import me.shedaniel.autoconfig.AutoConfig;
+
+public class ModMenuIntegration implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> AutoConfig.getConfigScreen(ChonkySheepConfig.class, parent)
+                .get();
+    }
+}

--- a/src/main/java/com/suppergerrie2/chonkysheep/entities/ChonkySheepEntity.java
+++ b/src/main/java/com/suppergerrie2/chonkysheep/entities/ChonkySheepEntity.java
@@ -25,7 +25,6 @@ import java.util.*;
 
 public class ChonkySheepEntity extends SheepEntity {
 
-    private static final int                            MAX_CHONKYNESS = 20;
     private static final TrackedData<Integer>           CHONKYNESS     = DataTracker.registerData(
             ChonkySheepEntity.class, TrackedDataHandlerRegistry.INTEGER);
     private static final Map<DyeColor, ItemConvertible> DROPS;
@@ -130,7 +129,7 @@ public class ChonkySheepEntity extends SheepEntity {
     }
 
     public void setChonkyness(int chonkyness) {
-        chonkyness = Math.min(MAX_CHONKYNESS, chonkyness);
+        chonkyness = Math.min(getMaxChonkyness(), chonkyness);
         this.dataTracker.set(CHONKYNESS, chonkyness);
     }
 
@@ -150,6 +149,6 @@ public class ChonkySheepEntity extends SheepEntity {
     }
 
     public int getMaxChonkyness() {
-        return MAX_CHONKYNESS;
+        return ChonkySheepMod.config.maxChonkyness;
     }
 }

--- a/src/main/java/com/suppergerrie2/chonkysheep/entities/ChonkySheepEntity.java
+++ b/src/main/java/com/suppergerrie2/chonkysheep/entities/ChonkySheepEntity.java
@@ -125,7 +125,7 @@ public class ChonkySheepEntity extends SheepEntity {
     }
 
     public int getChonkyness() {
-        return this.dataTracker.get(CHONKYNESS);
+        return Math.min(this.dataTracker.get(CHONKYNESS), getMaxChonkyness());
     }
 
     public void setChonkyness(int chonkyness) {
@@ -148,7 +148,7 @@ public class ChonkySheepEntity extends SheepEntity {
                       .orElseGet(() -> this.world.random.nextBoolean() ? firstParentColor : secondParentColor);
     }
 
-    public int getMaxChonkyness() {
+    public static int getMaxChonkyness() {
         return ChonkySheepMod.config.maxChonkyness;
     }
 }

--- a/src/main/java/com/suppergerrie2/chonkysheep/entities/rendering/ChonkySheepWoolEntityModel.java
+++ b/src/main/java/com/suppergerrie2/chonkysheep/entities/rendering/ChonkySheepWoolEntityModel.java
@@ -26,7 +26,7 @@ public class ChonkySheepWoolEntityModel extends QuadrupedEntityModel<ChonkySheep
         this.headAngle   = sheepEntity.getHeadAngle(h);
 
         //noinspection PointlessArithmeticExpression
-        scale = ((sheepEntity.getChonkyness() / (float) sheepEntity.getMaxChonkyness()) * (MAX_SCALE - 1)) + 1;
+        scale = ((sheepEntity.getChonkyness() / (float) ChonkySheepEntity.getMaxChonkyness()) * (MAX_SCALE - 1)) + 1;
     }
 
     public void setAngles(ChonkySheepEntity sheepEntity, float f, float g, float h, float i, float j) {

--- a/src/main/resources/assets/schonkysheep/lang/en_us.json
+++ b/src/main/resources/assets/schonkysheep/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "text.autoconfig.schonkysheep.option.maxChonkyness": "Maximum chonkyness of sheep",
+  "text.autoconfig.schonkysheep.title": "ChonkySheep"
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,10 @@
     ],
     "client": [
       "com.suppergerrie2.chonkysheep.ChonkySheepModClient"
-    ]
+    ],
+    "modmenu": [
+      "com.suppergerrie2.chonkysheep.ModMenuIntegration"
+      ]
   },
   "mixins": [
     "schonkysheep.mixins.json"
@@ -32,6 +35,7 @@
     "fabricloader": ">=0.11.3",
     "fabric": "*",
     "minecraft": "1.17.x",
-    "java": ">=16"
+    "java": ">=16",
+    "cloth-config2": ">=5.0.38"
   }
 }


### PR DESCRIPTION
- Make readme match mod description on curseforge
- Add dependency on Cloth Config
- Add optional dependency on Mod Menu
- Add a mod config
- Register the mod config in the main mod class
- Add a setting for the max chonkiness in the config, ranging from 0 (minimum value to avoid crashing) to 64 (arbitrary choice, minecraft's stack size)
- Use the maximum chonkiness set in the config to limit how chonky a sheep can grow
- Add a lang file to name the config value
- Register mod menu integration

closes #1 